### PR TITLE
Obs period fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: allofus
 Type: Package
 Title: Interface for 'All of Us' Researcher Workbench 
-Version: 1.0.0
+Version: 1.0.0.9000
 Authors@R: 
     c(
       person("Louisa", "Smith", email = "l.smith@northeastern.edu", role = c("aut", "cph"), comment = c(ORCID = "0000-0001-9029-4644")),

--- a/R/aou_obs_period.R
+++ b/R/aou_obs_period.R
@@ -74,7 +74,7 @@ aou_observation_period <- function(cohort = NULL,
       tmp <- dplyr::tbl(con, "visit_occurrence") %>%
         dplyr::inner_join(cohort, by = "person_id")
 
-      n = tally(cohort %>% dplyr::distinct("person_id")) %>% collect()
+      n = tally(cohort %>% dplyr::select("person_id") %>% distinct()) %>% dplyr::collect()
       n = n[[1,1]]
     }
   }
@@ -124,10 +124,11 @@ aou_observation_period <- function(cohort = NULL,
     dbplyr::window_order(.data$person_id, .data$obs_period) %>%
     dplyr::ungroup()
 
-  n_obs_period <- tally(obs_period %>% distinct("person_id")) %>% collect()
+  n_obs_period <- tally(obs_period %>% dplyr::select("person_id") %>% dplyr::distinct()) %>% dplyr::collect()
   n_obs_period <- n_obs_period[[1,1]]
 
-  if(n != n_obs_period){cli::cli_inform("warning for different number of people in obs period table")}
+  if(n != n_obs_period){cli::cli_inform("Warning: The number of participants in the cohort is different from the number of participants in the observation period.
+                                        This may be because not everyone in the cohort contributed electronic health record data.")}
 
   # collect if desired.
   if (isTRUE(collect)) {

--- a/R/aou_obs_period.R
+++ b/R/aou_obs_period.R
@@ -114,7 +114,7 @@ aou_observation_period <- function(cohort = NULL,
   n_obs_period <- tally(obs_period %>% distinct("person_id")) %>% collect()
   n_obs_period <- n_obs_period[[1,1]]
 
-  if(n != n_obs_period){warning("warning for different number of people in obs period table")}
+  if(n != n_obs_period){cli::cli_inform("warning for different number of people in obs period table")}
 
   # collect if desired.
   if (isTRUE(collect)) {

--- a/R/aou_obs_period.R
+++ b/R/aou_obs_period.R
@@ -51,9 +51,13 @@ aou_observation_period <- function(cohort = NULL,
     if (is.data.frame(cohort)) {
       tmp <- dplyr::tbl(con, "visit_occurrence") %>%
         dplyr::filter(.data$person_id %in% !!cohort$person_id)
+
+      n = nrow(cohort %>% dplyr::distinct("person_id"))
     } else {
       tmp <- dplyr::tbl(con, "visit_occurrence") %>%
         dplyr::inner_join(cohort, by = "person_id")
+
+      n = tally(cohort %>% dplyr::distinct("person_id"))
     }
   }
 
@@ -102,10 +106,16 @@ aou_observation_period <- function(cohort = NULL,
     dbplyr::window_order(.data$person_id, .data$obs_period) %>%
     dplyr::ungroup()
 
+  n_obs_period <- tally(obs_period %>% distinct("person_id"))
+
+  if(n != n_obs_period){warning("warning for different number of people in obs period table")}
+
   # collect if desired.
   if (isTRUE(collect)) {
     obs_period <- dplyr::collect(obs_period, ...)
   }
+
+
 
   return(obs_period)
 }

--- a/R/aou_obs_period.R
+++ b/R/aou_obs_period.R
@@ -57,7 +57,8 @@ aou_observation_period <- function(cohort = NULL,
       tmp <- dplyr::tbl(con, "visit_occurrence") %>%
         dplyr::inner_join(cohort, by = "person_id")
 
-      n = tally(cohort %>% dplyr::distinct("person_id"))
+      n = tally(cohort %>% dplyr::distinct("person_id")) %>% collect()
+      n = n[[1,1]]
     }
   }
 
@@ -106,7 +107,8 @@ aou_observation_period <- function(cohort = NULL,
     dbplyr::window_order(.data$person_id, .data$obs_period) %>%
     dplyr::ungroup()
 
-  n_obs_period <- tally(obs_period %>% distinct("person_id"))
+  n_obs_period <- tally(obs_period %>% distinct("person_id")) %>% collect()
+  n_obs_period <- n_obs_period[[1,1]]
 
   if(n != n_obs_period){warning("warning for different number of people in obs period table")}
 

--- a/R/aou_obs_period.R
+++ b/R/aou_obs_period.R
@@ -14,7 +14,20 @@
 #' @param ... Further arguments passed along to `collect()` if `collect = TRUE`
 #'
 #' @details
-#' Follows conventions described here: <https://ohdsi.github.io/CommonDataModel/ehrObsPeriods.html>
+#' The visit_occurrence table
+# is used to generate a new observation_period table based on OHDSI conventions here:
+#' <https://ohdsi.github.io/CommonDataModel/ehrObsPeriods.html>. The visit_occurrence table in the
+#' All of Us OMOP CDM contains dates from participant data collection visits which are excluded by default but can be included. Some of the
+#' visit lengths in the visit_occurrence table are unrealistically long for EHR data. These visits can be constrained
+#' by setting the `max_visit_length`, `max_op_visit_length`, and `max_er_visit_length` parameters. >99% of these visits are of the outpatient
+#' visit type, so its likely these are errors in the data. However, assuming these are errors, there's no way to determine whether the
+#' visit_start_date or visit_end_date are the actual visit date. Therefore, the function will exclude these visits when generating the
+#' observation period table.
+#'
+#' Users should note that the aou_observation_period function will only generate observation periods for
+#' participants who have at least one visit in the visit_occurrence table. If participant in the AllofUs research
+#' program who did not include electronic health record data are included in the cohort argument, they will not be included in the
+#' generated observation period table.
 #'
 #'
 #' @return a sql query or local data frame
@@ -35,7 +48,7 @@
 aou_observation_period <- function(cohort = NULL,
                                    persistence_window = 548,
                                    end_date_buffer = 60,
-                                   exclude_aou_visits = FALSE,
+                                   exclude_aou_visits = TRUE,
                                    con = getOption("aou.default.con"),
                                    collect = FALSE,
                                    max_visit_length = 1095, # 3 years

--- a/R/aou_obs_period.R
+++ b/R/aou_obs_period.R
@@ -8,7 +8,11 @@
 #' not part of the participants' typical EHR) from the observation period. Defaults to `FALSE`
 #' @param con Connection to the allofus SQL database. Defaults to getOption("aou.default.con"), which is set automatically if you use `aou_connect()`
 #' @param collect Whether to collect the data or keep as SQL query. Defaults to `FALSE`.
+#' @param max_visit_length max visit length for all visits
+#' @param max_op_visit_length max visit length for outpatient visits
+#' @param max_er_visit_length max visit length for emergency room visits
 #' @param ... Further arguments passed along to `collect()` if `collect = TRUE`
+#'
 #' @details
 #' Follows conventions described here: <https://ohdsi.github.io/CommonDataModel/ehrObsPeriods.html>
 #'

--- a/R/aou_obs_period.R
+++ b/R/aou_obs_period.R
@@ -127,7 +127,7 @@ aou_observation_period <- function(cohort = NULL,
   n_obs_period <- tally(obs_period %>% dplyr::select("person_id") %>% dplyr::distinct()) %>% dplyr::collect()
   n_obs_period <- n_obs_period[[1,1]]
 
-  if(n != n_obs_period){cli::cli_inform("Warning: The number of participants in the cohort is different from the number of participants in the observation period.
+  if(n != n_obs_period){cli::cli_inform("Warning: The number of participants in the cohort is different from the number of participants in the observation period table.
                                         This may be because not everyone in the cohort contributed electronic health record data.")}
 
   # collect if desired.

--- a/R/aou_obs_period.R
+++ b/R/aou_obs_period.R
@@ -83,9 +83,9 @@ aou_observation_period <- function(cohort = NULL,
     # some visits have ridiculous lengths - this is a fix for this for now.
     dplyr::filter(
       dplyr::case_when(
-        visit_length > 3 & visit_concept_id %in% op_visits ~ FALSE,
-        visit_length > 30 & visit_concept_id %in% er_visits ~ FALSE,
-        visit_length > 365 ~ FALSE,
+        visit_length > max_op_visit_length & visit_concept_id %in% op_visits ~ FALSE,
+        visit_length > max_er_visit_length & visit_concept_id %in% er_visits ~ FALSE,
+        visit_length > max_visit_length ~ FALSE,
         TRUE ~ TRUE
       )) %>% # filter out visits that are too long
     dplyr::group_by(.data$person_id) %>%

--- a/R/aou_obs_period.R
+++ b/R/aou_obs_period.R
@@ -64,7 +64,7 @@ aou_observation_period <- function(cohort = NULL,
 
   visit_concepts <- tbl(con, "concept") %>% select(concept_id, concept_name)
   op_visits <- c(9202, 581477,38004207)
-  er_visits <- c(9203, 262)
+  er_visits <- c(9203, 262, 8870)
 
   obs_period <-
     tmp %>%

--- a/man/aou_atlas_cohort.Rd
+++ b/man/aou_atlas_cohort.Rd
@@ -42,7 +42,19 @@ to generate the appropriate observation periods and incorporate other package fu
 Please see the online vignette for additional details insert link here
 }
 \details{
-Follows conventions described here: \url{https://ohdsi.github.io/CommonDataModel/ehrObsPeriods.html}
+The visit_occurrence table
+\url{https://ohdsi.github.io/CommonDataModel/ehrObsPeriods.html}. The visit_occurrence table in the
+All of Us OMOP CDM contains dates from participant data collection visits which are excluded by default but can be included. Some of the
+visit lengths in the visit_occurrence table are unrealistically long for EHR data. These visits can be constrained
+by setting the \code{max_visit_length}, \code{max_op_visit_length}, and \code{max_er_visit_length} parameters. >99\% of these visits are of the outpatient
+visit type, so its likely these are errors in the data. However, assuming these are errors, there's no way to determine whether the
+visit_start_date or visit_end_date are the actual visit date. Therefore, the function will exclude these visits when generating the
+observation period table.
+
+Users should note that the aou_observation_period function will only generate observation periods for
+participants who have at least one visit in the visit_occurrence table. If participant in the AllofUs research
+program who did not include electronic health record data are included in the cohort argument, they will not be included in the
+generated observation period table.
 }
 \examples{
 \dontshow{if (on_workbench()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/man/aou_observation_period.Rd
+++ b/man/aou_observation_period.Rd
@@ -8,7 +8,7 @@ aou_observation_period(
   cohort = NULL,
   persistence_window = 548,
   end_date_buffer = 60,
-  exclude_aou_visits = FALSE,
+  exclude_aou_visits = TRUE,
   con = getOption("aou.default.con"),
   collect = FALSE,
   max_visit_length = 1095,
@@ -47,7 +47,19 @@ a sql query or local data frame
 Generate an observation period table based on OMOP Conventions
 }
 \details{
-Follows conventions described here: \url{https://ohdsi.github.io/CommonDataModel/ehrObsPeriods.html}
+The visit_occurrence table
+\url{https://ohdsi.github.io/CommonDataModel/ehrObsPeriods.html}. The visit_occurrence table in the
+All of Us OMOP CDM contains dates from participant data collection visits which are excluded by default but can be included. Some of the
+visit lengths in the visit_occurrence table are unrealistically long for EHR data. These visits can be constrained
+by setting the \code{max_visit_length}, \code{max_op_visit_length}, and \code{max_er_visit_length} parameters. >99\% of these visits are of the outpatient
+visit type, so its likely these are errors in the data. However, assuming these are errors, there's no way to determine whether the
+visit_start_date or visit_end_date are the actual visit date. Therefore, the function will exclude these visits when generating the
+observation period table.
+
+Users should note that the aou_observation_period function will only generate observation periods for
+participants who have at least one visit in the visit_occurrence table. If participant in the AllofUs research
+program who did not include electronic health record data are included in the cohort argument, they will not be included in the
+generated observation period table.
 }
 \examples{
 \dontshow{if (on_workbench()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/man/aou_observation_period.Rd
+++ b/man/aou_observation_period.Rd
@@ -11,6 +11,9 @@ aou_observation_period(
   exclude_aou_visits = FALSE,
   con = getOption("aou.default.con"),
   collect = FALSE,
+  max_visit_length = 1095,
+  max_op_visit_length = 7,
+  max_er_visit_length = 30,
   ...
 )
 }
@@ -28,6 +31,12 @@ not part of the participants' typical EHR) from the observation period. Defaults
 \item{con}{Connection to the allofus SQL database. Defaults to getOption("aou.default.con"), which is set automatically if you use \code{aou_connect()}}
 
 \item{collect}{Whether to collect the data or keep as SQL query. Defaults to \code{FALSE}.}
+
+\item{max_visit_length}{max visit length for all visits}
+
+\item{max_op_visit_length}{max visit length for outpatient visits}
+
+\item{max_er_visit_length}{max visit length for emergency room visits}
 
 \item{...}{Further arguments passed along to \code{collect()} if \code{collect = TRUE}}
 }


### PR DESCRIPTION
This fixes a column naming error int he observation_period table. 

It also allows users to make an adjustment for visit lengths that are unreasonably long - removing these visits from contributing to the calculation of the observation period. 

updates checked on the workbench, documentation updated. 