### PR TITLE
Remove RStudio instruction 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,22 +49,6 @@ install.packages("pak")
 pak::pak("roux-ohdsi/allofus")
 ```
 
-On the new RStudio interface on the workbench, you will need to manually
-specify the CRAN mirror to be able to download *any* recently updated
-packages.
-
-``` r
-# specify the mirror directly
-install.packages("allofus", repos = "https://cloud.r-project.org")
-
-# OR set the mirror as an option at the top of your script
-options(repos = c(CRAN = "https://cloud.r-project.org"))
-
-# Github development versions may requires using the remotes package
-install.packages("remotes")
-remotes::install_github("roux-ohdsi/allofus", repos = "https://cloud.r-project.org")
-```
-
 ### Use
 
 Read through the [getting


### PR DESCRIPTION
AoU Workbench upgraded RStudio version to 3.19: https://www.bioconductor.org/packages/release/bioc/
This instruction is nolonger needed