### PR TITLE
Fix a package on load bug that cause aou.default.cdr unset

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -22,6 +22,7 @@
   }
 
   op <- options()
+  op <- op[sapply(op, function(x) !identical(x, ""))]
   op.aou <- list(
     aou.default.cdr = Sys.getenv("WORKSPACE_CDR"),
     aou.default.bucket = Sys.getenv("WORKSPACE_BUCKET"),


### PR DESCRIPTION
In AoU Rstudio, the `allofus` package will fail to connect even with the most current GitHub commit
```r
> library(allofus)
> con <- aou_connect()
Error:
! Unable to connect to CDR
Run `rlang::last_trace()` to see where the error occurred.
```

The root cause is that the option `aou.default.cdr` get a default of `""` instead of unset. 

```r
> getOption("aou.default.cdr")
[1] ""
```

This prevent it from being set by the package onload function as the following line only check the existence of the option rather than the actual value in the option

https://github.com/roux-ohdsi/allofus/blob/0c79a0075d7de5d744d2e76dcae28dfa4b3cf4af/R/zzz.R#L24-L30

This pull request adds a simple fix which exclude the empty string options before defining `toset`

```r
op <- op[sapply(op, function(x) !identical(x, ""))]
```

