### PR TITLE
Make the error more informative

### DIFF
--- a/R/aou_connect.R
+++ b/R/aou_connect.R
@@ -70,7 +70,17 @@ aou_connect <- function(CDR = getOption("aou.default.cdr"), ...) {
       )
 
       if (is.na(connection@dataset) | connection@dataset != release) {
-        stop()
+          stop(
+            sprintf(
+            "BigQuery connection dataset mismatch. Expected dataset '%s' but connection has dataset '%s'. Data project: '%s'. Billing project: '%s'. CDR input: '%s'.",
+            release,
+            as.character(connection@dataset),
+            prefix,
+            Sys.getenv("GOOGLE_PROJECT"),
+            CDR
+            ),
+            call. = FALSE
+        )
       }
 
       # also let it fail if there's no person_table
@@ -82,7 +92,11 @@ aou_connect <- function(CDR = getOption("aou.default.cdr"), ...) {
       connection
     },
     error = function(e) {
-      cli::cli_abort(c("Unable to connect to CDR {CDR}"), call = NULL)
+      cli::cli_abort(
+      c(
+        "Unable to connect to CDR {CDR}",
+        "Caused by: {conditionMessage(e)}"
+      ), call = NULL)
       return(e)
     }
   )


### PR DESCRIPTION
The current code does not return any error message beside a very generic one, which make it hard to understand

```r
> library(allofus)

> con <- aou_connect()
Error:
! Unable to connect to CDR
Run `rlang::last_trace()` to see where the error occurred.

> rlang::last_trace()
<error/rlang_error>
Error:
! Unable to connect to CDR
---
Backtrace:
    ▆
 1. └─allofus::aou_connect()
 2.   └─base::tryCatch(...)
 3.     └─base (local) tryCatchList(expr, classes, parentenv, handlers)
 4.       └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
 5.         └─value[[3L]](cond)
Run rlang::last_trace(drop = FALSE) to see 2 hidden frames.
```

The issue is that the `trycatch` block in `aou_connect` called `cli::cli_abort` when encountered an error and cause a hard stop, `return(e)` will never be reachable (and user cannot catch it)

https://github.com/roux-ohdsi/allofus/blob/0c79a0075d7de5d744d2e76dcae28dfa4b3cf4af/R/aou_connect.R#L84-L87

To make it more information, I attached the error message to `cli::cli_abort`, so we will have a better error message for debug

```r
> con = aou_connect()
Error:
! Unable to connect to CDR
Caused by: `project` must be a single string, not a character `NA`.
Run `rlang::last_trace()` to see where the error occurred.
```





